### PR TITLE
Ft user must able create account #160926746

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -1,0 +1,17 @@
+import bcrypt from 'bcryptjs';
+import db from '../db/index';
+/* eslint-disable class-methods-use-this */
+class AuthController {
+  register(req, res) {
+    // email, password, address, name
+    return res.status(200).json({
+      name: req.body.name,
+      password: req.body.password,
+      email: req.body.email,
+      address: req.body.address,
+    });
+  }
+}
+
+const authcontroller = new AuthController();
+export default authcontroller;

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -5,12 +5,6 @@ import valid from '../js/shared';
 class AuthController {
   register(req, res) {
     // email, password, address, name
-    const isValid = valid.validate(req.body.email);
-    if (!isValid) {
-      return res.status(400).json({
-        message: 'Email format is wrong',
-      });
-    }
     const password = bcrypt.hashSync('req.body.password', 10);
     const params = [req.body.name, req.body.email, password, req.body.address];
     db.query('INSERT INTO users(name, email, password, address) VALUES($1,$2,$3,$4)', params, (err) => {

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -11,11 +11,20 @@ class AuthController {
         message: 'Email format is wrong',
       });
     }
-    return res.status(200).json({
-      name: req.body.name,
-      password: req.body.password,
-      email: req.body.email,
-      address: req.body.address,
+    const password = bcrypt.hashSync('req.body.password', 10);
+    const params = [req.body.name, req.body.email, password, req.body.address];
+    db.query('INSERT INTO users(name, email, password, address) VALUES($1,$2,$3,$4)', params, (err) => {
+      if (err) {
+        console.log(err);
+      }
+      return res.status(200).json({
+        request: {
+          name: req.body.name,
+          email: req.body.email,
+          address: req.body.address,
+        },
+        message: 'Registered Successfully',
+      });
     });
   }
 }

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -1,9 +1,16 @@
 import bcrypt from 'bcryptjs';
 import db from '../db/index';
+import valid from '../js/shared';
 /* eslint-disable class-methods-use-this */
 class AuthController {
   register(req, res) {
     // email, password, address, name
+    const isValid = valid.validate(req.body.email);
+    if (!isValid) {
+      return res.status(400).json({
+        message: 'Email format is wrong',
+      });
+    }
     return res.status(200).json({
       name: req.body.name,
       password: req.body.password,

--- a/db/dropTable.js
+++ b/db/dropTable.js
@@ -12,6 +12,12 @@ db.query('DROP TABLE IF EXISTS foodlist', (err) => {
   }
 });
 
+db.query('DROP TABLE IF EXISTS users', (err) => {
+  if (err) {
+    console.log(err);
+  }
+});
+
 db.query('DROP TYPE IF EXISTS status', (err) => {
   if (err) {
     console.log(err);

--- a/db/table.js
+++ b/db/table.js
@@ -23,3 +23,15 @@ image text NOT NULL
     console.log(err);
   }
 });
+
+db.query(`CREATE TABLE users(
+id serial PRIMARY KEY,
+name text NOT NULL,
+email text NOT NULL,
+password text NOT NULL,
+address text NOT NULL
+)`, (err) => {
+  if (err) {
+    console.log(err);
+  }
+});

--- a/dist/controllers/auth.js
+++ b/dist/controllers/auth.js
@@ -38,11 +38,20 @@ var AuthController = function () {
           message: 'Email format is wrong'
         });
       }
-      return res.status(200).json({
-        name: req.body.name,
-        password: req.body.password,
-        email: req.body.email,
-        address: req.body.address
+      var password = _bcryptjs2.default.hashSync('req.body.password', 10);
+      var params = [req.body.name, req.body.email, password, req.body.address];
+      _index2.default.query('INSERT INTO users(name, email, password, address) VALUES($1,$2,$3,$4)', params, function (err) {
+        if (err) {
+          console.log(err);
+        }
+        return res.status(200).json({
+          request: {
+            name: req.body.name,
+            email: req.body.email,
+            address: req.body.address
+          },
+          message: 'Registered Successfully'
+        });
       });
     }
   }]);

--- a/dist/controllers/auth.js
+++ b/dist/controllers/auth.js
@@ -1,0 +1,40 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _index = require('../db/index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+/* eslint-disable class-methods-use-this */
+var AuthController = function () {
+  function AuthController() {
+    _classCallCheck(this, AuthController);
+  }
+
+  _createClass(AuthController, [{
+    key: 'register',
+    value: function register(req, res) {
+      // email, password, address, name
+      return res.status(200).json({
+        name: req.body.name,
+        password: req.body.password,
+        email: req.body.email,
+        address: req.body.address
+      });
+    }
+  }]);
+
+  return AuthController;
+}();
+
+var authcontroller = new AuthController();
+exports.default = authcontroller;

--- a/dist/controllers/auth.js
+++ b/dist/controllers/auth.js
@@ -6,9 +6,17 @@ Object.defineProperty(exports, "__esModule", {
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
+var _bcryptjs = require('bcryptjs');
+
+var _bcryptjs2 = _interopRequireDefault(_bcryptjs);
+
 var _index = require('../db/index');
 
 var _index2 = _interopRequireDefault(_index);
+
+var _shared = require('../js/shared');
+
+var _shared2 = _interopRequireDefault(_shared);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -24,6 +32,12 @@ var AuthController = function () {
     key: 'register',
     value: function register(req, res) {
       // email, password, address, name
+      var isValid = _shared2.default.validate(req.body.email);
+      if (!isValid) {
+        return res.status(400).json({
+          message: 'Email format is wrong'
+        });
+      }
       return res.status(200).json({
         name: req.body.name,
         password: req.body.password,

--- a/dist/controllers/auth.js
+++ b/dist/controllers/auth.js
@@ -32,12 +32,6 @@ var AuthController = function () {
     key: 'register',
     value: function register(req, res) {
       // email, password, address, name
-      var isValid = _shared2.default.validate(req.body.email);
-      if (!isValid) {
-        return res.status(400).json({
-          message: 'Email format is wrong'
-        });
-      }
       var password = _bcryptjs2.default.hashSync('req.body.password', 10);
       var params = [req.body.name, req.body.email, password, req.body.address];
       _index2.default.query('INSERT INTO users(name, email, password, address) VALUES($1,$2,$3,$4)', params, function (err) {

--- a/dist/db/dropTable.js
+++ b/dist/db/dropTable.js
@@ -18,6 +18,12 @@ _index2.default.query('DROP TABLE IF EXISTS foodlist', function (err) {
   }
 });
 
+_index2.default.query('DROP TABLE IF EXISTS users', function (err) {
+  if (err) {
+    console.log(err);
+  }
+});
+
 _index2.default.query('DROP TYPE IF EXISTS status', function (err) {
   if (err) {
     console.log(err);

--- a/dist/db/table.js
+++ b/dist/db/table.js
@@ -17,3 +17,9 @@ _index2.default.query('CREATE TABLE foodlist(\nid serial PRIMARY KEY,\nfood text
     console.log(err);
   }
 });
+
+_index2.default.query('CREATE TABLE users(\nid serial PRIMARY KEY,\nname text NOT NULL,\nemail text NOT NULL,\npassword text NOT NULL,\naddress text NOT NULL\n)', function (err) {
+  if (err) {
+    console.log(err);
+  }
+});

--- a/dist/index.js
+++ b/dist/index.js
@@ -24,6 +24,10 @@ var _foodlist = require('./routes/foodlist');
 
 var _foodlist2 = _interopRequireDefault(_foodlist);
 
+var _auth = require('./routes/auth');
+
+var _auth2 = _interopRequireDefault(_auth);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 _dotenv2.default.config();
@@ -36,6 +40,7 @@ app.use('/uploads', _express2.default.static('uploads'));
 // use routes folder
 app.use('/api/v1', _orders2.default);
 app.use('/api/v1', _foodlist2.default);
+app.use('/api/v1', _auth2.default);
 
 app.get('/', function (req, res) {
   res.status(200).send({

--- a/dist/js/authmiddleware.js
+++ b/dist/js/authmiddleware.js
@@ -27,5 +27,15 @@ exports.default = {
       });
     }
     next();
+  },
+  validate: function validate(req, res, next) {
+    var re = /\S+@\S+\.\S+/;
+    var valid = re.test(req.body.email);
+    if (!valid) {
+      return res.status(400).json({
+        message: 'Email format is wrong'
+      });
+    }
+    next();
   }
 };

--- a/dist/js/authmiddleware.js
+++ b/dist/js/authmiddleware.js
@@ -1,0 +1,31 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = {
+  verifyBody: function verifyBody(req, res, next) {
+    if (!req.body.email) {
+      // partial content
+      return res.status(206).json({
+        message: 'Email must be included in the body'
+      });
+    }if (!req.body.password) {
+      // partial content
+      return res.status(206).json({
+        message: 'password must be included in the body'
+      });
+    }if (!req.body.address) {
+      // partial content
+      return res.status(206).json({
+        message: 'Address must be included in the body'
+      });
+    }if (!req.body.name) {
+      // partial content
+      return res.status(206).json({
+        message: 'Name must be included in the body'
+      });
+    }
+    next();
+  }
+};

--- a/dist/js/shared.js
+++ b/dist/js/shared.js
@@ -78,5 +78,9 @@ exports.default = {
       return req.protocol + '://' + req.headers.host + '/uploads\\default.jpg';
     }
     return req.protocol + '://' + req.headers.host + '/' + req.file.path;
+  },
+  validate: function validate(email) {
+    var re = /\S+@\S+\.\S+/;
+    return re.test(email);
   }
 };

--- a/dist/js/shared.js
+++ b/dist/js/shared.js
@@ -78,9 +78,5 @@ exports.default = {
       return req.protocol + '://' + req.headers.host + '/uploads\\default.jpg';
     }
     return req.protocol + '://' + req.headers.host + '/' + req.file.path;
-  },
-  validate: function validate(email) {
-    var re = /\S+@\S+\.\S+/;
-    return re.test(email);
   }
 };

--- a/dist/routes/auth.js
+++ b/dist/routes/auth.js
@@ -1,0 +1,24 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _express = require('express');
+
+var _auth = require('../controllers/auth');
+
+var _auth2 = _interopRequireDefault(_auth);
+
+var _authmiddleware = require('../js/authmiddleware');
+
+var _authmiddleware2 = _interopRequireDefault(_authmiddleware);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// initialize router
+var router = (0, _express.Router)();
+
+router.post('/auth/signup', [_authmiddleware2.default.verifyBody], _auth2.default.register);
+
+exports.default = router;

--- a/dist/routes/auth.js
+++ b/dist/routes/auth.js
@@ -19,6 +19,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 // initialize router
 var router = (0, _express.Router)();
 
-router.post('/auth/signup', [_authmiddleware2.default.verifyBody], _auth2.default.register);
+router.post('/auth/signup', [_authmiddleware2.default.verifyBody, _authmiddleware2.default.validate], _auth2.default.register);
 
 exports.default = router;

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import bodyParser from 'body-parser';
 import dotenv from 'dotenv';
 import apiRoutes from './routes/orders';
 import userRoutes from './routes/foodlist';
+import authRoutes from './routes/auth';
 
 dotenv.config();
 const app = express();
@@ -14,6 +15,7 @@ app.use('/uploads', express.static('uploads'));
 // use routes folder
 app.use('/api/v1', apiRoutes);
 app.use('/api/v1', userRoutes);
+app.use('/api/v1', authRoutes);
 
 app.get('/', (req, res) => {
   res.status(200).send({

--- a/js/authmiddleware.js
+++ b/js/authmiddleware.js
@@ -1,0 +1,26 @@
+export default {
+  verifyBody: (req, res, next) => {
+    if (!req.body.email) {
+      // partial content
+      return res.status(206).json({
+        message: 'Email must be included in the body',
+      });
+    } if (!req.body.password) {
+      // partial content
+      return res.status(206).json({
+        message: 'password must be included in the body',
+      });
+    } if (!req.body.address) {
+      // partial content
+      return res.status(206).json({
+        message: 'Address must be included in the body',
+      });
+    } if (!req.body.name) {
+      // partial content
+      return res.status(206).json({
+        message: 'Name must be included in the body',
+      });
+    }
+    next();
+  },
+};

--- a/js/authmiddleware.js
+++ b/js/authmiddleware.js
@@ -23,4 +23,14 @@ export default {
     }
     next();
   },
+  validate: (req, res, next) => {
+    const re = /\S+@\S+\.\S+/;
+    const valid = re.test(req.body.email);
+    if (!valid) {
+      return res.status(400).json({
+        message: 'Email format is wrong',
+      });
+    }
+    next();
+  },
 };

--- a/js/shared.js
+++ b/js/shared.js
@@ -74,4 +74,8 @@ export default {
     }
     return `${req.protocol}://${req.headers.host}/${req.file.path}`;
   },
+  validate(email) {
+    const re = /\S+@\S+\.\S+/;
+    return re.test(email);
+  },
 };

--- a/js/shared.js
+++ b/js/shared.js
@@ -1,5 +1,5 @@
 export default {
-  verifyBody(req, res, next) {
+  verifyBody: (req, res, next) => {
     if (!req.body.food) {
       return res.status(400).send({
         status: 'Bad Request',
@@ -13,7 +13,7 @@ export default {
     }
     next();
   },
-  verifyBodyandQuantity(req, res, next) {
+  verifyBodyandQuantity: (req, res, next) => {
     if (!req.body.food) {
       return res.status(400).send({
         status: 'Bad Request',
@@ -32,7 +32,7 @@ export default {
     }
     next();
   },
-  verifyLenghtOfVariables(req, res, next) {
+  verifyLenghtOfVariables: (req, res, next) => {
     const foodAdded = req.body.food.split(',');
     const quantity = req.body.quantity.split(',');
     const price = req.body.price.split(',');
@@ -55,10 +55,10 @@ export default {
     }
     next();
   },
-  generateRandomNumber() {
+  generateRandomNumber: () => {
     return Math.floor(Math.random() * 10 + 1);
   },
-  generateID(food) {
+  generateID: (food) => {
     let id = 0;
     if (food[food.length - 1].id === undefined) {
       id = 1;
@@ -67,15 +67,11 @@ export default {
     }
     return id;
   },
-  imagePicker(req) {
+  imagePicker: (req) => {
     if (!req.file) {
       // set default image
       return `${req.protocol}://${req.headers.host}/uploads\\default.jpg`;
     }
     return `${req.protocol}://${req.headers.host}/${req.file.path}`;
-  },
-  validate(email) {
-    const re = /\S+@\S+\.\S+/;
-    return re.test(email);
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1121,6 +1121,11 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Danielshow",
   "license": "ISC",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",
     "dotenv": "^6.0.0",
     "express": "^4.16.3",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -5,6 +5,6 @@ import body from '../js/authmiddleware';
 // initialize router
 const router = Router();
 
-router.post('/auth/signup', [body.verifyBody], AuthController.register);
+router.post('/auth/signup', [body.verifyBody, body.validate], AuthController.register);
 
 export default router;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import AuthController from '../controllers/auth';
+import body from '../js/authmiddleware';
+
+// initialize router
+const router = Router();
+
+router.post('/auth/signup', [body.verifyBody], AuthController.register);
+
+export default router;


### PR DESCRIPTION
## This PR let users create an account to register and store their credentials in a database

## Task
- Integrate PostgreSQL
- Add `auth/signup` route
- Hash user password using bcrypt module
- Send a message after a success

#### Steps to Reproduce
- Send a request to API  endpoint `api/v1/auth/signup`
```bash
POST `api/v1/auth/signup`
```
### TEST
```bash
1. Clone this repo using `git clone https://github.com/Danielshow/Fast-Food`
2. Checkout to this branch using `ft-user-must-able-create-account-#160926746`
3. `npm install` to install the dependencies
4. `npm start` will get the server running
5. send a POST request to `api/v1/auth/signup`
```
## Pivotal tracker stories
https://www.pivotaltracker.com/n/projects/2193646
