### PR TITLE
Restrict admin from seeing profile page and placing orders #161300484

### DIFF
--- a/Front End Template/javascript/order.js
+++ b/Front End Template/javascript/order.js
@@ -167,6 +167,8 @@ const loadWindowsAndCheckAuth = (() => {
     }).then(response => response.json()).then((data) => {
       if (data.status !== 200) {
         window.location.replace('./login.html');
+      } if (data.data[0].roles === 'admin') {
+        window.location.replace('./admin-page.html');
       }
       fetch(`${url}menu`, {
         headers: {

--- a/Front End Template/javascript/profile.js
+++ b/Front End Template/javascript/profile.js
@@ -74,6 +74,8 @@ window.addEventListener('load', () => {
     }).then(response => response.json()).then((data) => {
       if (data.status !== 200) {
         window.location.replace('./login.html');
+      }  if (data.data[0].roles === 'admin') {
+        window.location.replace('./admin-page.html');
       }
       const { name } = data.data[0];
       id = data.data[0].id;

--- a/dist/controllers/auth.js
+++ b/dist/controllers/auth.js
@@ -1,0 +1,125 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _bcryptjs = require('bcryptjs');
+
+var _bcryptjs2 = _interopRequireDefault(_bcryptjs);
+
+var _jsonwebtoken = require('jsonwebtoken');
+
+var _jsonwebtoken2 = _interopRequireDefault(_jsonwebtoken);
+
+var _index = require('../db/index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+/* eslint-disable class-methods-use-this */
+var AuthController = function () {
+  function AuthController() {
+    _classCallCheck(this, AuthController);
+  }
+
+  _createClass(AuthController, [{
+    key: 'register',
+    value: function register(req, res, next) {
+      var password = _bcryptjs2.default.hashSync(req.body.password, 10);
+      var params = [req.body.name.trim().toLowerCase(), req.body.email.trim().toLowerCase(), password, req.body.address.trim().toLowerCase(), 'user'];
+      _index2.default.query('INSERT INTO users(name, email, password, address, roles) VALUES($1,$2,$3,$4,$5)', params, function (err) {
+        if (err) {
+          return next(err);
+        }
+        return res.status(200).json({
+          TYPE: 'POST',
+          status: 200,
+          data: {
+            name: req.body.name.trim(),
+            email: req.body.email.trim(),
+            address: req.body.address.trim()
+          },
+          message: 'Registered Successfully'
+        });
+      });
+    }
+  }, {
+    key: 'login',
+    value: function login(req, res, next) {
+      _index2.default.query('SELECT * from users WHERE email=$1', [req.body.email.toLowerCase()], function (err, data) {
+        if (err) {
+          return next(err);
+        }
+        if (data.rows.length > 0) {
+          var compare = _bcryptjs2.default.compareSync(req.body.password, data.rows[0].password);
+          if (compare) {
+            var token = _jsonwebtoken2.default.sign({
+              email: data.rows[0].email,
+              userid: data.rows[0].id
+            }, process.env.JWT_KEY, {
+              expiresIn: 86400
+            });
+            return res.status(200).json({
+              TYPE: 'POST',
+              status: 200,
+              data: {
+                token: token,
+                roles: data.rows[0].roles
+              },
+              message: 'Login Successful'
+            });
+          }
+          return res.status(403).json({
+            TYPE: 'POST',
+            status: 403,
+            message: 'Incorrect email or password'
+          });
+        }
+      });
+    }
+  }, {
+    key: 'logout',
+    value: function logout(req, res, next) {
+      res.status(200).json({
+        type: 'GET',
+        status: 200,
+        data: {
+          token: null
+        },
+        message: 'User logged out Successfully'
+      });
+    }
+  }, {
+    key: 'getMe',
+    value: function getMe(req, res, next) {
+      _index2.default.query('SELECT * from users where id=$1', [req.decoded.userid], function (err, data) {
+        if (err) {
+          return next(err);
+        }
+        if (data.rows.length > 0) {
+          return res.status(200).send({
+            type: 'GET',
+            status: 200,
+            data: data.rows,
+            message: 'User returned Successfully'
+          });
+        }
+        return res.status(404).json({
+          status: 400,
+          message: 'User not found'
+        });
+      });
+    }
+  }]);
+
+  return AuthController;
+}();
+
+var authcontroller = new AuthController();
+exports.default = authcontroller;

--- a/dist/controllers/menu.js
+++ b/dist/controllers/menu.js
@@ -1,0 +1,163 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _shared = require('../middleware/shared');
+
+var _shared2 = _interopRequireDefault(_shared);
+
+var _index = require('../db/index');
+
+var _index2 = _interopRequireDefault(_index);
+
+var _cloudinary = require('../middleware/cloudinary');
+
+var _cloudinary2 = _interopRequireDefault(_cloudinary);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+/* eslint-disable class-methods-use-this */
+var FoodListController = function () {
+  function FoodListController() {
+    _classCallCheck(this, FoodListController);
+  }
+
+  _createClass(FoodListController, [{
+    key: 'getAllFood',
+    value: function getAllFood(req, res, next) {
+      _index2.default.query('SELECT * FROM foodlist', function (err, data) {
+        if (err) {
+          return next(err);
+        }
+        return res.status(200).json({
+          TYPE: 'GET',
+          status: 200,
+          data: data.rows,
+          message: 'Food Returned Successfully'
+        });
+      });
+    }
+  }, {
+    key: 'getFood',
+    value: function getFood(req, res, next) {
+      var id = req.params.id;
+
+      _index2.default.query('SELECT * FROM foodlist WHERE id=$1', [id], function (err, data) {
+        if (err) {
+          return next(err);
+        }
+        if (data.rows.length > 0) {
+          return res.status(200).json({
+            TYPE: 'GET',
+            status: 200,
+            data: data.rows[0],
+            message: 'Food returned Successfully'
+          });
+        }
+        return res.status(404).json({
+          TYPE: 'GET',
+          status: 404,
+          message: 'Food not found'
+        });
+      });
+    }
+  }, {
+    key: 'postFood',
+    value: function postFood(req, res, next) {
+      var image = null;
+      if (!req.file) {
+        image = req.imagepath;
+      } else {
+        image = req.file.path;
+      }
+      _cloudinary2.default.uploader.upload(image, function (result) {
+        _index2.default.query('INSERT INTO foodlist(food, price, image) VALUES($1,$2,$3)', [req.body.food, req.body.price, result.secure_url], function (err) {
+          if (err) {
+            return next(err);
+          }
+          return res.status(200).json({
+            TYPE: 'POST',
+            status: 200,
+            data: {
+              food: req.body.food.trim(),
+              price: Number(req.body.price),
+              image: result.secure_url
+            },
+            message: 'Food Added Successfully'
+          });
+        });
+      });
+    }
+  }, {
+    key: 'updateFood',
+    value: function updateFood(req, res, next) {
+      var id = req.params.id;
+
+      var image = null;
+      if (!req.file) {
+        image = req.imagepath;
+      } else {
+        image = req.file.path;
+      }
+      _cloudinary2.default.uploader.upload(image, function (result) {
+        _index2.default.query('UPDATE foodlist SET food=$1,price=$2,image=$3 WHERE id=$4', [req.body.food, req.body.price, result.secure_url, id], function (err) {
+          if (err) {
+            return next(err);
+          }
+          return res.status(200).json({
+            TYPE: 'PUT',
+            status: 200,
+            data: {
+              food: req.body.food.trim(),
+              price: Number(req.body.price),
+              image: result.secure_url
+            },
+            message: 'Food Updated'
+          });
+        });
+      });
+    }
+  }, {
+    key: 'deleteFood',
+    value: function deleteFood(req, res, next) {
+      var id = req.params.id;
+
+      _index2.default.query('DELETE from foodlist WHERE id=$1', [id], function (err) {
+        if (err) {
+          return next(err);
+        }
+        return res.status(200).json({
+          TYPE: 'DELETE',
+          status: 200,
+          message: 'Food deleted'
+        });
+      });
+    }
+  }, {
+    key: 'getTotal',
+    value: function getTotal(req, res, next) {
+      _index2.default.query('SELECT sum(price) from ORDERS', function (err, data) {
+        if (err) {
+          return next(err);
+        }
+        return res.status(200).json({
+          TYPE: 'GET',
+          status: 200,
+          data: data.rows[0].sum,
+          message: 'Success, Total Returned'
+        });
+      });
+    }
+  }]);
+
+  return FoodListController;
+}();
+
+var foodlistController = new FoodListController();
+exports.default = foodlistController;

--- a/dist/controllers/orders.js
+++ b/dist/controllers/orders.js
@@ -1,0 +1,156 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _index = require('../db/index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+/* eslint-disable class-methods-use-this */
+var OrderController = function () {
+  function OrderController() {
+    _classCallCheck(this, OrderController);
+  }
+
+  _createClass(OrderController, [{
+    key: 'getAllOrder',
+    value: function getAllOrder(req, res, next) {
+      _index2.default.query('SELECT * FROM orders', function (err, data) {
+        if (err) {
+          return next(err);
+        }
+        return res.status(200).json({
+          TYPE: 'GET',
+          status: 200,
+          data: data.rows,
+          message: 'Orders returned successfully'
+        });
+      });
+    }
+  }, {
+    key: 'getOrder',
+    value: function getOrder(req, res, next) {
+      var id = req.params.id;
+
+      _index2.default.query('SELECT * FROM orders WHERE id=$1', [id], function (err, data) {
+        if (err) {
+          return next(err);
+        }
+        if (data.rows.length > 0) {
+          return res.status(200).json({
+            TYPE: 'GET',
+            status: 200,
+            data: data.rows[0],
+            message: 'Order returned Successfully'
+          });
+        }
+        return res.status(404).json({
+          TYPE: 'GET',
+          status: 404,
+          message: 'Food not found'
+        });
+      });
+    }
+  }, {
+    key: 'getUserOrder',
+    value: function getUserOrder(req, res, next) {
+      var id = req.params.id;
+
+      _index2.default.query('SELECT * FROM orders WHERE user_id=$1', [id], function (err, data) {
+        if (err) {
+          return next(err);
+        }
+        if (data.rows.length > 0) {
+          return res.status(200).json({
+            TYPE: 'GET',
+            status: 200,
+            data: data.rows,
+            message: 'food returned Successfully'
+          });
+        }
+        return res.status(404).json({
+          TYPE: 'GET',
+          status: 404,
+          message: 'Food by user not found'
+        });
+      });
+    }
+  }, {
+    key: 'postOrder',
+    value: function postOrder(req, res, next) {
+      var quantity = req.body.quantity.split(',');
+      var food = req.body.food.split(',');
+      var price = req.body.price.split(',');
+      var userId = req.decoded.userid;
+      var addedPrice = 0;
+      for (var i = 0; i < quantity.length; i += 1) {
+        addedPrice += Number(price[i].trim()) * Number(quantity[i].trim());
+      }
+      price = addedPrice;
+      var quantityList = [];
+      var foodlist = [];
+      for (var j = 0; j < food.length; j += 1) {
+        quantityList.push(quantity[j].trim());
+        foodlist.push(food[j].trim());
+      }
+      _index2.default.query('INSERT INTO orders(food,quantity,price,user_id,status) VALUES($1,$2,$3,$4,$5)', [foodlist.join(','), quantityList.join(','), price, userId, 'new'], function (err) {
+        if (err) {
+          return next(err);
+        }
+        return res.status(200).json({
+          TYPE: 'POST',
+          status: 200,
+          data: {
+            food: food,
+            quantity: quantity,
+            price: price,
+            status: 'new',
+            userId: userId
+          },
+          message: 'Food Added to order list Successfully'
+        });
+      });
+    }
+  }, {
+    key: 'updateOrderStatus',
+    value: function updateOrderStatus(req, res, next) {
+      if (!req.body.status || req.body.status.trim().length < 1) {
+        return res.status(206).json({
+          TYPE: 'PUT',
+          status: 206,
+          message: 'Status Not sent'
+        });
+      }
+      var status = req.body.status;
+      var id = req.params.id;
+
+      _index2.default.query('UPDATE orders SET status=$1 WHERE id=$2', [status.toLowerCase(), id], function (err) {
+        if (err) {
+          return res.status(400).send({
+            TYPE: 'PUT',
+            status: 400,
+            message: 'status should be either New,Processing,Cancelled or Complete.'
+          });
+        }
+        return res.status(200).json({
+          TYPE: 'PUT',
+          status: 200,
+          message: 'Food Status Updated'
+        });
+      });
+    }
+  }]);
+
+  return OrderController;
+}();
+
+var orderController = new OrderController();
+exports.default = orderController;

--- a/dist/controllers/users.js
+++ b/dist/controllers/users.js
@@ -1,0 +1,86 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _index = require('../db/index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+/* eslint-disable class-methods-use-this */
+var UsersController = function () {
+  function UsersController() {
+    _classCallCheck(this, UsersController);
+  }
+
+  _createClass(UsersController, [{
+    key: 'getAllUsers',
+    value: function getAllUsers(req, res, next) {
+      _index2.default.query('select * from users', function (err, data) {
+        if (err) {
+          return next(err);
+        }
+        return res.status(200).json({
+          type: 'GET',
+          status: 200,
+          data: data.rows,
+          message: 'All users returned successfully'
+        });
+      });
+    }
+  }, {
+    key: 'deleteAccount',
+    value: function deleteAccount(req, res, next) {
+      _index2.default.query('Delete from users where id=$1', [req.decoded.userid], function (err) {
+        if (err) {
+          return next(err);
+        }
+        return res.status(200).json({
+          type: 'DELETE',
+          status: 200,
+          message: 'Account successfully deleted'
+        });
+      });
+    }
+  }, {
+    key: 'deleteUsers',
+    value: function deleteUsers(req, res, next) {
+      _index2.default.query('DELETE from users where id=$1', [req.params.id], function (err) {
+        if (err) {
+          return next(err);
+        }
+        return res.status(200).json({
+          type: 'DELETE',
+          status: 200,
+          message: 'User Deleted successfully'
+        });
+      });
+    }
+  }, {
+    key: 'promoteUsers',
+    value: function promoteUsers(req, res, next) {
+      _index2.default.query('Update users SET roles=$1 where id=$2', [req.body.roles.toLowerCase(), req.params.id], function (err) {
+        if (err) {
+          return next(err);
+        }
+        return res.status(200).json({
+          type: 'PUT',
+          status: 200,
+          message: 'User promoted to admin successfully'
+        });
+      });
+    }
+  }]);
+
+  return UsersController;
+}();
+
+var usersController = new UsersController();
+exports.default = usersController;

--- a/dist/db/defaultadmin.js
+++ b/dist/db/defaultadmin.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var _bcryptjs = require('bcryptjs');
+
+var _bcryptjs2 = _interopRequireDefault(_bcryptjs);
+
+var _index = require('./index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var password = _bcryptjs2.default.hashSync('admin1', 10);
+var params = ['admin', 'admin2@foodfast.com', password, 'Default address', 'admin'];
+_index2.default.query('INSERT INTO users(name, email, password, address, roles) VALUES($1,$2,$3,$4,$5)', params, function (err) {
+  if (err) {
+    console.log(err);
+  }
+});

--- a/dist/db/dropTable.js
+++ b/dist/db/dropTable.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var _index = require('./index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+_index2.default.query('DROP TABLE IF EXISTS orders', function (err) {
+  if (err) {
+    console.log(err);
+  }
+});
+
+_index2.default.query('DROP TABLE IF EXISTS foodlist', function (err) {
+  if (err) {
+    console.log(err);
+  }
+});
+
+_index2.default.query('DROP TABLE IF EXISTS users', function (err) {
+  if (err) {
+    console.log(err);
+  }
+});
+
+_index2.default.query('DROP TYPE IF EXISTS status', function (err) {
+  if (err) {
+    console.log(err);
+  }
+  _index2.default.query('CREATE TYPE status AS ENUM (\'new\', \'processing\', \'cancelled\', \'complete\')', function (error) {
+    if (err) {
+      console.log(error);
+    }
+  });
+});
+
+_index2.default.query('DROP TYPE IF EXISTS roles', function (err) {
+  if (err) {
+    console.log(err);
+  }
+  _index2.default.query('CREATE TYPE roles AS ENUM (\'user\', \'admin\')', function (error) {
+    if (err) {
+      console.log(error);
+    }
+  });
+});

--- a/dist/db/index.js
+++ b/dist/db/index.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var _pg = require('pg');
+
+var _dotenv = require('dotenv');
+
+var _dotenv2 = _interopRequireDefault(_dotenv);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+_dotenv2.default.config();
+
+var pool = new _pg.Pool();
+// create table
+// node-postgres.com
+module.exports = {
+  query: function query(text, params, callback) {
+    pool.query(text, params, callback);
+  }
+};

--- a/dist/db/table.js
+++ b/dist/db/table.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var _index = require('./index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+_index2.default.query('CREATE TABLE users(\nid serial PRIMARY KEY,\nname text NOT NULL,\nemail text NOT NULL,\npassword text NOT NULL,\naddress text NOT NULL,\nroles roles NOT NULL\n)', function (err) {
+  if (err) {
+    console.log(err);
+  }
+  _index2.default.query('create table orders(\n  id serial PRIMARY KEY,\n  food text NOT NULL,\n  quantity text NOT NULL,\n  price numeric NOT NULL,\n  user_id integer References users(id) on DELETE CASCADE,\n  status status NOT NULL\n  )', function (err) {
+    if (err) {
+      console.log(err);
+    }
+  });
+});
+
+_index2.default.query('CREATE TABLE foodlist(\nid serial PRIMARY KEY,\nfood text NOT NULL,\nprice numeric NOT NULL,\nimage text NOT NULL\n)', function (err) {
+  if (err) {
+    console.log(err);
+  }
+});

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,90 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _express = require('express');
+
+var _express2 = _interopRequireDefault(_express);
+
+var _bodyParser = require('body-parser');
+
+var _bodyParser2 = _interopRequireDefault(_bodyParser);
+
+var _dotenv = require('dotenv');
+
+var _dotenv2 = _interopRequireDefault(_dotenv);
+
+var _orders = require('./routes/orders');
+
+var _orders2 = _interopRequireDefault(_orders);
+
+var _menu = require('./routes/menu');
+
+var _menu2 = _interopRequireDefault(_menu);
+
+var _auth = require('./routes/auth');
+
+var _auth2 = _interopRequireDefault(_auth);
+
+var _users = require('./routes/users');
+
+var _users2 = _interopRequireDefault(_users);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+_dotenv2.default.config();
+var app = (0, _express2.default)();
+// bodyparser middleware
+app.use(_bodyParser2.default.json());
+app.use(_bodyParser2.default.urlencoded({ extended: false }));
+
+app.use(_express2.default.static('Front End Template'));
+
+app.use(function (req, res, next) {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Headers', 'Access-Control-Allow-Origin, X-Requested-With, Content-Type, Accept, Authorization');
+  if (req.method === 'OPTIONS') {
+    res.header('Access-Control-Allow-Methods', 'PUT, POST, GET, DELETE, PATCH');
+    return res.status(200).json({});
+  }
+  next();
+});
+
+app.use(function (err, req, res, next) {
+  res.status(500).json({
+    message: err.message
+  });
+});
+// use routes folder
+app.use('/api/v1', _orders2.default);
+app.use('/api/v1', _menu2.default);
+app.use('/api/v1', _auth2.default);
+app.use('/api/v1', _users2.default);
+
+app.get('/api/v1', function (req, res) {
+  res.status(200).send({
+    product: 'Welcome to Food Fast API',
+    message: '/api/v1 before every route'
+  });
+});
+// custom 404 handler
+app.use(function (req, res, next) {
+  var error = new Error('Not Found');
+  error.status = 404;
+  next(error);
+});
+
+// error handling
+app.use(function (error, req, res, next) {
+  res.status(error.status || 500);
+  res.send({
+    error: error.message
+  });
+});
+app.listen(process.env.PORT, function () {
+  console.log('Server Listen on port ' + process.env.PORT);
+});
+
+exports.default = app;

--- a/dist/middleware/auth.js
+++ b/dist/middleware/auth.js
@@ -1,0 +1,165 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _index = require('../db/index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var isPassword = function isPassword(password) {
+  var re = /\w+/;
+  return re.test(password);
+};
+
+var isSpaceInPassword = function isSpaceInPassword(password) {
+  var re = /\s+/;
+  return re.test(password);
+};
+
+exports.default = {
+  verifyBody: function verifyBody(req, res, next) {
+    if (!req.body.email || req.body.email.trim().length < 1) {
+      return res.status(206).json({
+        status: 206,
+        message: 'Email must be included in the body'
+      });
+    }if (!req.body.password) {
+      return res.status(206).json({
+        status: 206,
+        message: 'password must be included in the body'
+      });
+    }if (!req.body.address || req.body.address.trim().length < 1) {
+      return res.status(206).json({
+        status: 206,
+        message: 'Address must be included in the body'
+      });
+    }if (!req.body.name || req.body.name.trim().length < 1) {
+      return res.status(206).json({
+        status: 206,
+        message: 'Name must be included in the body'
+      });
+    }
+    return next();
+  },
+  verifyRoles: function verifyRoles(req, res, next) {
+    var roles = req.body.roles.toLowerCase();
+    if (!req.body.roles || req.body.roles.trim().length < 1) {
+      return res.status(400).json({
+        status: 400,
+        message: 'roles must be included in the body'
+      });
+    }if (roles !== 'admin' && roles !== 'user') {
+      return res.status(400).json({
+        status: '400',
+        message: 'Roles must be either Admin or Users'
+      });
+    }
+    return next();
+  },
+  validate: function validate(req, res, next) {
+    var re = /\S+@\S+\.\S+/;
+    var valid = re.test(req.body.email.trim());
+    if (!valid) {
+      return res.status(400).json({
+        status: 400,
+        message: 'Email format is wrong'
+      });
+    }
+    return next();
+  },
+  verifySignin: function verifySignin(req, res, next) {
+    if (!req.body.email || req.body.email.trim().length < 1) {
+      return res.status(206).json({
+        status: 206,
+        message: 'Email must be included in the body'
+      });
+    }if (!req.body.password || req.body.password.trim().length < 1) {
+      return res.status(206).json({
+        status: 206,
+        message: 'password must be included in the body'
+      });
+    }
+    return next();
+  },
+  isEmailExist: function isEmailExist(req, res, next) {
+    _index2.default.query('SELECT email from users', function (err, data) {
+      if (err) {
+        return next(err);
+      }
+      for (var i = 0; i < data.rows.length; i += 1) {
+        if (data.rows[i].email.toLowerCase() === req.body.email.trim().toLowerCase()) {
+          return res.status(409).send({
+            status: 400,
+            message: 'Email already exist'
+          });
+        }
+      }
+      return next();
+    });
+  },
+  isEmailInDb: function isEmailInDb(req, res, next) {
+    _index2.default.query('SELECT email from users', function (err, data) {
+      if (err) {
+        return next(err);
+      }
+      for (var i = 0; i < data.rows.length; i += 1) {
+        if (data.rows[i].email.toLowerCase() === req.body.email.trim().toLowerCase()) {
+          return next();
+        }
+      }
+      return res.status(403).json({
+        status: 403,
+        message: 'Incorrect email or password'
+      });
+    });
+  },
+  isValidID: function isValidID(req, res, next) {
+    if (isNaN(req.params.id) || Number(req.params.id) > 9000) {
+      return res.status(403).json({
+        status: 403,
+        message: 'ID must be a number and less than 9000'
+      });
+    }
+    return next();
+  },
+  confirmPassword: function confirmPassword(req, res, next) {
+    if (!req.body.password || !req.body.confirmpassword) {
+      return res.status(400).json({
+        status: 400,
+        message: 'body must contain password and confirmpassword'
+      });
+    }
+    if (req.body.password.length < 6) {
+      return res.status(206).json({
+        status: 206,
+        message: 'password must be a minimum of 6 characters'
+      });
+    }
+    if (req.body.password.trim() !== req.body.confirmpassword.trim()) {
+      return res.status(400).json({
+        status: 400,
+        message: 'password and confirmpassword not equal'
+      });
+    }
+    return next();
+  },
+  isPasswordValid: function isPasswordValid(req, res, next) {
+    if (!isPassword(req.body.password)) {
+      return res.status(400).json({
+        status: 400,
+        message: 'Password must contain Letters or numbers'
+      });
+    }
+    if (isSpaceInPassword(req.body.password)) {
+      return res.status(400).json({
+        status: 400,
+        message: 'password must not contain spaces'
+      });
+    }
+    return next();
+  }
+};

--- a/dist/middleware/checkAuth.js
+++ b/dist/middleware/checkAuth.js
@@ -1,0 +1,96 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _jsonwebtoken = require('jsonwebtoken');
+
+var _jsonwebtoken2 = _interopRequireDefault(_jsonwebtoken);
+
+var _index = require('../db/index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = {
+  verifyToken: function verifyToken(req, res, next) {
+    try {
+      var token = req.headers.authorization.split(' ')[1];
+      var decoded = _jsonwebtoken2.default.verify(token, process.env.JWT_KEY);
+      req.decoded = decoded;
+      return next();
+    } catch (err) {
+      if (req.headers.authorization) {
+        return res.status(401).json({
+          status: 401,
+          message: 'Authentication fail, Incorrect Token'
+        });
+      }
+      return res.status(403).json({
+        status: 403,
+        message: 'Authentication fail, Please provide Token'
+      });
+    }
+  },
+
+  verifyAdminToken: function verifyAdminToken(req, res, next) {
+    try {
+      var token = req.headers.authorization.split(' ')[1];
+      var decoded = _jsonwebtoken2.default.verify(token, process.env.JWT_KEY);
+      req.decoded = decoded;
+      _index2.default.query('SELECT * from users WHERE email=$1', [decoded.email], function (err, data) {
+        if (err) {
+          return next(err);
+        }
+        if (data.rows.length > 0) {
+          if (data.rows[0].roles === 'admin') {
+            return next();
+          }
+          return res.status(403).json({
+            status: 403,
+            message: 'You are not authorize to do this'
+          });
+        }
+      });
+    } catch (err) {
+      if (req.headers.authorization) {
+        return res.status(401).json({
+          status: 401,
+          message: 'Authentication fail, Incorrect Token'
+        });
+      }
+      return res.status(403).json({
+        status: 403,
+        message: 'Authentication fail, Please provide Token'
+      });
+    }
+  },
+
+  isUserResource: function isUserResource(req, res, next) {
+    try {
+      var token = req.headers.authorization.split(' ')[1];
+      var decoded = _jsonwebtoken2.default.verify(token, process.env.JWT_KEY);
+      req.decoded = decoded;
+      if (Number(decoded.userid) !== Number(req.params.id)) {
+        return res.status(403).send({
+          status: 403,
+          message: 'Auth Fail, You are not authorize to view this resource'
+        });
+      }
+      return next();
+    } catch (err) {
+      if (req.headers.authorization) {
+        return res.status(401).json({
+          status: 401,
+          message: 'Authentication fail, Incorrect Token'
+        });
+      }
+      return res.status(403).json({
+        status: 403,
+        message: 'Authentication fail, Please provide Token'
+      });
+    }
+  }
+};

--- a/dist/middleware/cloudinary.js
+++ b/dist/middleware/cloudinary.js
@@ -1,0 +1,19 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _cloudinary = require('cloudinary');
+
+var _cloudinary2 = _interopRequireDefault(_cloudinary);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+_cloudinary2.default.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET
+});
+
+exports.default = _cloudinary2.default;

--- a/dist/middleware/list_verify.js
+++ b/dist/middleware/list_verify.js
@@ -1,0 +1,26 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var listVerify = function listVerify(req, res, next) {
+  var price = req.body.price.split(',');
+  var food = req.body.food.split(',');
+  var quantity = req.body.quantity.split(',');
+
+  for (var i = 0; i < price.length; i += 1) {
+    if (isNaN(price[i].trim()) || isNaN(quantity[i].trim())) {
+      return res.status(400).json({
+        message: 'Bad request, Price and quantity must be a Number'
+      });
+    }
+    if (food[i].trim() === '') {
+      return res.status(400).json({
+        message: 'Bad Request, Food at position ' + (i + 1) + ' cannot be empty'
+      });
+    }
+  }
+  return next();
+};
+
+exports.default = listVerify;

--- a/dist/middleware/multer_config.js
+++ b/dist/middleware/multer_config.js
@@ -1,0 +1,33 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _multer = require('multer');
+
+var _multer2 = _interopRequireDefault(_multer);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var storage = _multer2.default.diskStorage({
+  filename: function filename(req, file, cb) {
+    cb(null, new Date().toISOString().replace(/:/g, '-'));
+  }
+});
+var fileFilter = function fileFilter(req, file, cb) {
+  if (file.mimetype === 'image/jpeg' || file.mimetype === 'image/png' || file.mimetype === 'image/jpg') {
+    cb(null, true);
+  } else {
+    cb(new Error('Only image files are allowed'), false);
+  }
+};
+var upload = (0, _multer2.default)({
+  storage: storage,
+  limits: {
+    fileSize: 1024 * 1024 * 4
+  },
+  fileFilter: fileFilter
+});
+
+exports.default = upload;

--- a/dist/middleware/read_file.js
+++ b/dist/middleware/read_file.js
@@ -1,0 +1,32 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _index = require('../db/index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// check if food is available, return true
+var isFoodAvailable = function isFoodAvailable(req, res, next) {
+  _index2.default.query('SELECT food from foodlist', function (err, data) {
+    if (err) {
+      return next(err);
+    }
+    for (var i = 0; i < data.rows.length; i += 1) {
+      if (req.body.food.trim().toLowerCase() === data.rows[i].food.toLowerCase()) {
+        return res.status(409).json({
+          status: 409,
+          message: 'Food Already in FoodList'
+        });
+      }
+    }
+    next();
+  });
+};
+exports.default = {
+  isFoodAvailable: isFoodAvailable
+};

--- a/dist/middleware/shared.js
+++ b/dist/middleware/shared.js
@@ -1,0 +1,83 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _cloudinary = require('./cloudinary');
+
+var _cloudinary2 = _interopRequireDefault(_cloudinary);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = {
+  verifyBody: function verifyBody(req, res, next) {
+    if (!req.body.food || req.body.food.trim().length < 1) {
+      return res.status(400).send({
+        status: 400,
+        message: 'Request must contain food'
+      });
+    }if (!req.body.price) {
+      return res.status(400).send({
+        status: 400,
+        message: 'Request must contain Price'
+      });
+    }if (isNaN(req.body.price)) {
+      return res.status(400).send({
+        status: 'Bad Request',
+        message: 'Price must be Number'
+      });
+    }
+    next();
+  },
+  verifyBodyandQuantity: function verifyBodyandQuantity(req, res, next) {
+    if (!req.body.food || req.body.food.trim().length < 1) {
+      return res.status(400).send({
+        status: 400,
+        message: 'Request must contain food'
+      });
+    }if (!req.body.price || req.body.price.trim().length < 1) {
+      return res.status(400).send({
+        status: 400,
+        message: 'Request must contain Price'
+      });
+    }if (!req.body.quantity || req.body.quantity.trim().length < 1) {
+      return res.status(400).send({
+        status: 400,
+        message: 'Request must contain Quantity of foods'
+      });
+    }
+    next();
+  },
+  verifyLenghtOfVariables: function verifyLenghtOfVariables(req, res, next) {
+    var foodAdded = req.body.food.trim().split(',');
+    var quantity = req.body.quantity.trim().split(',');
+    var price = req.body.price.trim().split(',');
+    if (foodAdded.length > quantity.length) {
+      // partial content
+      return res.status(206).send({
+        status: 206,
+        message: '1 or more quantity(s) is missing'
+      });
+    }if (quantity.length > foodAdded.length) {
+      return res.status(206).send({
+        status: 206,
+        message: '1 or more food(s) is missing'
+      });
+    }if (quantity.length !== price.length) {
+      return res.status(206).send({
+        status: '206',
+        message: 'Price for each food is incomplete'
+      });
+    }
+    next();
+  },
+  isFileAvailable: function isFileAvailable(req, res, next) {
+    if (!req.file) {
+      req.imagepath = 'https://res.cloudinary.com/fast-food/image/upload/v1539909326/l0cvazx1fh1x8cjeu9ag.jpg';
+      return next();
+    }
+    return next();
+    // return `${req.protocol}://${req.headers.host}/${req.file.path}`;
+  }
+};

--- a/dist/routes/auth.js
+++ b/dist/routes/auth.js
@@ -1,0 +1,30 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _express = require('express');
+
+var _auth = require('../controllers/auth');
+
+var _auth2 = _interopRequireDefault(_auth);
+
+var _auth3 = require('../middleware/auth');
+
+var _auth4 = _interopRequireDefault(_auth3);
+
+var _checkAuth = require('../middleware/checkAuth');
+
+var _checkAuth2 = _interopRequireDefault(_checkAuth);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// initialize router
+var router = (0, _express.Router)();
+
+router.post('/auth/signup', [_auth4.default.verifyBody, _auth4.default.isPasswordValid, _auth4.default.confirmPassword, _auth4.default.validate, _auth4.default.isEmailExist], _auth2.default.register);
+router.post('/auth/login', [_auth4.default.verifySignin, _auth4.default.isEmailInDb], _auth2.default.login);
+router.get('/auth/me', _checkAuth2.default.verifyToken, _auth2.default.getMe);
+router.get('/auth/logout', _checkAuth2.default.verifyToken, _auth2.default.logout);
+exports.default = router;

--- a/dist/routes/menu.js
+++ b/dist/routes/menu.js
@@ -1,0 +1,50 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _express = require('express');
+
+var _multer_config = require('../middleware/multer_config');
+
+var _multer_config2 = _interopRequireDefault(_multer_config);
+
+var _menu = require('../controllers/menu');
+
+var _menu2 = _interopRequireDefault(_menu);
+
+var _shared = require('../middleware/shared');
+
+var _shared2 = _interopRequireDefault(_shared);
+
+var _read_file = require('../middleware/read_file');
+
+var _read_file2 = _interopRequireDefault(_read_file);
+
+var _checkAuth = require('../middleware/checkAuth');
+
+var _checkAuth2 = _interopRequireDefault(_checkAuth);
+
+var _auth = require('../middleware/auth');
+
+var _auth2 = _interopRequireDefault(_auth);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// initialize router
+var router = (0, _express.Router)();
+
+// get food list available on the webpage
+router.get('/menu', _checkAuth2.default.verifyToken, _menu2.default.getAllFood);
+// get foodlist by ID
+router.get('/menu/:id', _checkAuth2.default.verifyToken, [_auth2.default.isValidID], _menu2.default.getFood);
+// post new food to foodlist by admin
+router.post('/menu', _checkAuth2.default.verifyAdminToken, _multer_config2.default.single('foodImage'), [_shared2.default.verifyBody, _shared2.default.isFileAvailable, _read_file2.default.isFoodAvailable], _menu2.default.postFood);
+// Admin can update food from foodList
+router.put('/menu/:id', _checkAuth2.default.verifyAdminToken, _multer_config2.default.single('foodImage'), [_auth2.default.isValidID, _shared2.default.verifyBody, _shared2.default.isFileAvailable, _read_file2.default.isFoodAvailable], _menu2.default.updateFood);
+// Delete food from foodList
+router.delete('/menu/:id', _checkAuth2.default.verifyAdminToken, [_auth2.default.isValidID], _menu2.default.deleteFood);
+// get the price of all food ordered by users
+router.get('/total', _checkAuth2.default.verifyAdminToken, _menu2.default.getTotal);
+exports.default = router;

--- a/dist/routes/orders.js
+++ b/dist/routes/orders.js
@@ -1,0 +1,45 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _express = require('express');
+
+var _orders = require('../controllers/orders');
+
+var _orders2 = _interopRequireDefault(_orders);
+
+var _shared = require('../middleware/shared');
+
+var _shared2 = _interopRequireDefault(_shared);
+
+var _checkAuth = require('../middleware/checkAuth');
+
+var _checkAuth2 = _interopRequireDefault(_checkAuth);
+
+var _auth = require('../middleware/auth');
+
+var _auth2 = _interopRequireDefault(_auth);
+
+var _list_verify = require('../middleware/list_verify');
+
+var _list_verify2 = _interopRequireDefault(_list_verify);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// initialize router
+var router = (0, _express.Router)();
+
+// get user orders for admin page
+router.get('/orders', _checkAuth2.default.verifyAdminToken, _orders2.default.getAllOrder);
+// get one order by ID
+router.get('/orders/:id', _checkAuth2.default.verifyAdminToken, [_auth2.default.isValidID], _orders2.default.getOrder);
+// get orders by a specific logged in user by their user_id
+router.get('/users/:id/orders', [_auth2.default.isValidID], _checkAuth2.default.isUserResource, _orders2.default.getUserOrder);
+// post new orders to the admin page by users
+router.post('/orders', _checkAuth2.default.verifyToken, [_shared2.default.verifyBodyandQuantity, _shared2.default.verifyLenghtOfVariables, _list_verify2.default], _orders2.default.postOrder);
+// Edit order Status declined, completed, pending by admin
+router.put('/orders/:id', _checkAuth2.default.verifyAdminToken, [_auth2.default.isValidID], _orders2.default.updateOrderStatus);
+
+exports.default = router;

--- a/dist/routes/users.js
+++ b/dist/routes/users.js
@@ -1,0 +1,29 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _express = require('express');
+
+var _users = require('../controllers/users');
+
+var _users2 = _interopRequireDefault(_users);
+
+var _checkAuth = require('../middleware/checkAuth');
+
+var _checkAuth2 = _interopRequireDefault(_checkAuth);
+
+var _auth = require('../middleware/auth');
+
+var _auth2 = _interopRequireDefault(_auth);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var router = (0, _express.Router)();
+
+router.get('/users', _checkAuth2.default.verifyAdminToken, _users2.default.getAllUsers);
+router.delete('/users', _checkAuth2.default.verifyToken, _users2.default.deleteAccount);
+router.delete('/users/:id', _checkAuth2.default.verifyAdminToken, _auth2.default.isValidID, _users2.default.deleteUsers);
+router.put('/users/:id', _checkAuth2.default.verifyAdminToken, _auth2.default.isValidID, _auth2.default.verifyRoles, _users2.default.promoteUsers);
+exports.default = router;

--- a/dist/test/auth.js
+++ b/dist/test/auth.js
@@ -1,0 +1,277 @@
+'use strict';
+
+var _chai = require('chai');
+
+var _chai2 = _interopRequireDefault(_chai);
+
+var _chaiHttp = require('chai-http');
+
+var _chaiHttp2 = _interopRequireDefault(_chaiHttp);
+
+var _index = require('../index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var expect = _chai2.default.expect;
+
+var should = _chai2.default.should();
+_chai2.default.use(_chaiHttp2.default);
+
+var token = process.env.TOKEN1;
+var token2 = process.env.TOKEN2;
+
+var newUser = {
+  email: 'danielshoit@gmail.com',
+  name: 'opeyemi',
+  password: 'daniel',
+  confirmpassword: 'daniel',
+  address: 'Ikorodu'
+};
+
+var fakeUser = {
+  email: 'daniels@gmail.com',
+  name: 'opeyemi',
+  password: 'daniel',
+  confirmpassword: 'dan',
+  address: 'Ikorodu'
+};
+
+var admin = {
+  email: 'admin22@fastfood.com',
+  name: 'opeyemi',
+  password: 'daniel',
+  confirmpassword: 'daniel',
+  address: 'Ikorodu'
+};
+
+var testUser = {
+  name: 'daniel',
+  password: 'tolu',
+  address: 'Lagos'
+};
+
+var newUserLogin = {
+  email: 'danielshoit@gmail.com',
+  password: 'daniel'
+};
+// .set('Authorization', `Bearer ${token}`)
+// sign up
+describe('API endpoint for POST auth/signup', function () {
+  it('Should register user given a valid credentials, and a user supply their email, name, password and address', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/signup').send(newUser).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body.data).to.be.an('Object');
+      res.body.data.should.have.property('name');
+      res.body.data.should.have.property('email').eql('danielshoit@gmail.com');
+      res.body.data.should.have.property('address').eql('Ikorodu');
+      res.body.should.have.property('message').eql('Registered Successfully');
+    });
+  });
+
+  it('Should Return error if email field is empty or email field has whitespace only', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/signup').send(testUser).then(function (res) {
+      expect(res).to.have.status(206);
+      res.body.should.have.property('message').eql('Email must be included in the body');
+    });
+  });
+
+  it('Should Return error if password field is empty or password field has only whitespace', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/signup').send({
+      email: 'daniels@gmail.com',
+      address: 'Home address'
+    }).then(function (res) {
+      expect(res).to.have.status(206);
+      res.body.should.have.property('message').eql('password must be included in the body');
+    });
+  });
+
+  it('Should Return error if email syntax is wrong, Email syntax should be dan@yahoo.com', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/signup').send({
+      email: 'danielsgmail.com',
+      address: 'Home address',
+      name: 'opeyemi',
+      password: 'daniel',
+      confirmpassword: 'daniel'
+    }).then(function (res) {
+      expect(res).to.have.status(400);
+      res.body.should.have.property('message').eql('Email format is wrong');
+    });
+  });
+
+  it('Should Return error if email exists in the database. Email must be unique', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/signup').send({
+      email: 'admin2@foodfast.com',
+      address: 'Home address',
+      name: 'opeyemi',
+      password: 'daniel',
+      confirmpassword: 'daniel'
+    }).then(function (res) {
+      expect(res).to.have.status(409);
+      res.body.should.have.property('message').eql('Email already exist');
+    });
+  });
+
+  it('Should Return error if password is not equal to confirm password', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/signup').send(fakeUser).then(function (res) {
+      expect(res).to.have.status(400);
+      res.body.should.have.property('message').eql('password and confirmpassword not equal');
+    });
+  });
+
+  it('Should Return error if password length is less than 6', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/signup').send({
+      email: 'admin@foodfast.com',
+      address: 'Home address',
+      name: 'opeyemi',
+      password: 'dani',
+      confirmpassword: 'dani'
+    }).then(function (res) {
+      expect(res).to.have.status(206);
+      res.body.should.have.property('message').eql('password must be a minimum of 6 characters');
+    });
+  });
+
+  it('Should Return error if password length is less than 6', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/signup').send({
+      email: 'admin@foodfast.com',
+      address: 'Home address',
+      name: 'opeyemi',
+      password: 'dani'
+    }).then(function (res) {
+      expect(res).to.have.status(400);
+      res.body.should.have.property('message').eql('body must contain password and confirmpassword');
+    });
+  });
+
+  it('Password should contain letters or numbers and any other characters', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/signup').send({
+      email: 'admin@foodfast.com',
+      address: 'Home address',
+      name: 'opeyemi',
+      password: '......',
+      confirmpassword: '......'
+    }).then(function (res) {
+      expect(res).to.have.status(400);
+      res.body.should.have.property('message').eql('Password must contain Letters or numbers');
+    });
+  });
+
+  it('Password should not contain spaces', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/signup').send({
+      email: 'admin@foodfast.com',
+      address: 'Home address',
+      name: 'opeyemi',
+      password: 'zjj zz',
+      confirmpassword: 'ajj zz'
+    }).then(function (res) {
+      expect(res).to.have.status(400);
+      res.body.should.have.property('message').eql('password must not contain spaces');
+    });
+  });
+});
+
+// signin
+describe('API endpoint for POST auth/login', function () {
+  it('Should Login user given a valid credentials and user supply email and password', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/login').send(newUserLogin).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body).to.be.an('Object');
+      res.body.should.have.property('message').eql('Login Successful');
+      res.body.should.have.property('data');
+      res.body.data.should.have.property('token');
+    });
+  });
+
+  it('Should Return error if email is not included or email contain only whitespace', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/login').send({
+      password: 'daniel'
+    }).then(function (res) {
+      expect(res).to.have.status(206);
+      expect(res.body).to.be.an('Object');
+      res.body.should.have.property('message').eql('Email must be included in the body');
+    });
+  });
+
+  it('Should Return error if password is not included or password contain only whitespace', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/login').send({
+      email: 'daniel@yahoo.com'
+    }).then(function (res) {
+      expect(res).to.have.status(206);
+      expect(res.body).to.be.an('Object');
+      res.body.should.have.property('message').eql('password must be included in the body');
+    });
+  });
+
+  it('Should Return error if email does not exist, User must register before Login', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/login').send({
+      email: 'danielopeyemi@yahoo.com',
+      password: 'daniele'
+    }).then(function (res) {
+      expect(res).to.have.status(403);
+      expect(res.body).to.be.an('Object');
+      res.body.should.have.property('message').eql('Incorrect email or password');
+    });
+  });
+
+  it('Should Return error if password is wrong', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/auth/login').send({
+      email: 'danielshoit@gmail.com',
+      password: 'dani jjele'
+    }).then(function (res) {
+      expect(res).to.have.status(403);
+      expect(res.body).to.be.an('Object');
+      res.body.should.have.property('message').eql('Incorrect email or password');
+    });
+  });
+});
+// admin login
+
+describe('API endpoint GET /auth/me', function () {
+  it('Should return a particular user with all his/her credentials', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/auth/me').set('Authorization', 'Bearer ' + token2).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body.data).to.be.an('Array');
+      res.body.should.have.property('message').eql('User returned Successfully');
+    });
+  });
+
+  it('Should return failed if Token is not sent', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/auth/me').then(function (res) {
+      expect(res).to.have.status(403);
+      res.body.should.have.property('message').eql('Authentication fail, Please provide Token');
+    });
+  });
+
+  it('Should send an error if an Invalid token is sent. Token must be send with the header', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/auth/me').set('Authorization', 'Bearer jdjdj').then(function (res) {
+      expect(res).to.have.status(401);
+      res.body.should.have.property('message').eql('Authentication fail, Incorrect Token');
+    });
+  });
+});
+
+describe('API endpoint GET /auth/logout', function () {
+  it('Should logout a particular user and set token to null', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/auth/logout').set('Authorization', 'Bearer ' + token2).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body.data).to.be.an('Object');
+      res.body.should.have.property('message').eql('User logged out Successfully');
+    });
+  });
+
+  it('Should return failed if Token is not sent', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/auth/me').then(function (res) {
+      expect(res).to.have.status(403);
+      res.body.should.have.property('message').eql('Authentication fail, Please provide Token');
+    });
+  });
+
+  it('Should send an error if an Invalid token is sent. Token must be send with the header', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/auth/me').set('Authorization', 'Bearer jdjdj').then(function (res) {
+      expect(res).to.have.status(401);
+      res.body.should.have.property('message').eql('Authentication fail, Incorrect Token');
+    });
+  });
+});

--- a/dist/test/menu.js
+++ b/dist/test/menu.js
@@ -1,0 +1,163 @@
+'use strict';
+
+var _chai = require('chai');
+
+var _chai2 = _interopRequireDefault(_chai);
+
+var _chaiHttp = require('chai-http');
+
+var _chaiHttp2 = _interopRequireDefault(_chaiHttp);
+
+var _index = require('../index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var expect = _chai2.default.expect;
+
+var should = _chai2.default.should();
+_chai2.default.use(_chaiHttp2.default);
+// token
+var token = process.env.TOKEN1;
+var dantoken = process.env.TOKEN2;
+
+// for post FoodList
+var food = {
+  food: 'rice',
+  price: 3000
+};
+
+var updateFood = {
+  food: 'meat',
+  price: 5000
+};
+
+var wrongfood = {
+  food: '    ',
+  price: 67
+};
+
+var wrongfood2 = {
+  food: 'sphagetti'
+};
+
+describe('API endpoint POST /menu', function () {
+  it('Should post food to the food menu given food field is not empty', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/menu').set('Authorization', 'Bearer ' + token).send(food).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body.data).to.be.an('Object');
+      res.body.data.should.have.property('food').eql('rice');
+      res.body.data.should.have.property('price').eql(3000);
+      res.body.data.should.have.property('image');
+    });
+  });
+
+  it('Should return error given food field is empty', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/menu').set('Authorization', 'Bearer ' + token).send(wrongfood).then(function (res) {
+      expect(res).to.have.status(400);
+      expect(res.body).to.be.an('Object');
+      res.body.should.have.property('status').eql(400);
+      res.body.should.have.property('message').eql('Request must contain food');
+    });
+  });
+
+  it('Should return error given price field is empty', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/menu').set('Authorization', 'Bearer ' + token).send(wrongfood2).then(function (res) {
+      expect(res).to.have.status(400);
+      expect(res.body).to.be.an('Object');
+      res.body.should.have.property('status').eql(400);
+      res.body.should.have.property('message').eql('Request must contain Price');
+    });
+  });
+
+  it('Should return error if food already exist', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/menu').set('Authorization', 'Bearer ' + token).send(food).then(function (res) {
+      expect(res).to.have.status(409);
+      expect(res.body).to.be.an('Object');
+      res.body.should.have.property('message').eql('Food Already in FoodList');
+    });
+  });
+});
+
+describe('API endpoint GET /menu', function () {
+  it('Should return all foods in the foodlist', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/menu').set('Authorization', 'Bearer ' + dantoken).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body).to.be.an('object');
+      expect(res.body.data).to.be.an('Array');
+      expect(res.body.data[0]).to.be.an('object');
+      expect(res.body.data[0]).to.have.property('id');
+    });
+  });
+
+  it('Should return one food from the folldlist when accessed through the food ID', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/menu/1').set('Authorization', 'Bearer ' + dantoken).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body).to.be.an('object');
+      expect(res.body.data).to.have.property('id');
+    });
+  });
+
+  it('Should return not found when food ID is not in the database', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/menu/100').set('Authorization', 'Bearer ' + dantoken).then(function (res) {
+      expect(res).to.have.status(404);
+      expect(res.body).to.be.an('object');
+      res.body.should.have.property('message').eql('Food not found');
+    });
+  });
+});
+
+describe('API endpoint to Delete food from foodlist', function () {
+  it('Should delete food from foodlist with a specified ID and return food deleted', function () {
+    return _chai2.default.request(_index2.default).delete('/api/v1/menu/1').set('Authorization', 'Bearer ' + token).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body).to.be.an('object');
+      res.body.should.have.property('message').eql('Food deleted');
+    });
+  });
+});
+
+describe('API endpoint PUT /menu', function () {
+  it('Should update food given food field and price is not empty', function () {
+    return _chai2.default.request(_index2.default).put('/api/v1/menu/1').set('Authorization', 'Bearer ' + token).send(updateFood).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body.data).to.be.an('Object');
+      res.body.data.should.have.property('food').eql('meat');
+      res.body.data.should.have.property('price').eql(5000);
+      res.body.should.have.property('message').eql('Food Updated');
+    });
+  });
+
+  it('Price must be a number', function () {
+    return _chai2.default.request(_index2.default).put('/api/v1/menu/1').set('Authorization', 'Bearer ' + token).send({
+      food: 'plantian chips',
+      price: '600'
+    }).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body.data.price).to.be.a('number');
+    });
+  });
+
+  it('Should return error given food field is empty', function () {
+    return _chai2.default.request(_index2.default).put('/api/v1/menu/1').set('Authorization', 'Bearer ' + token).send({
+      price: 780
+    }).then(function (res) {
+      expect(res).to.have.status(400);
+      expect(res.body).to.be.an('Object');
+      res.body.should.have.property('status').eql(400);
+      res.body.should.have.property('message').eql('Request must contain food');
+    });
+  });
+
+  it('Should return error given price field is empty', function () {
+    return _chai2.default.request(_index2.default).put('/api/v1/menu/1').set('Authorization', 'Bearer ' + token).send({
+      food: 'Dodo'
+    }).then(function (res) {
+      expect(res).to.have.status(400);
+      expect(res.body).to.be.an('Object');
+      res.body.should.have.property('status').eql(400);
+      res.body.should.have.property('message').eql('Request must contain Price');
+    });
+  });
+});

--- a/dist/test/orders.js
+++ b/dist/test/orders.js
@@ -1,0 +1,158 @@
+'use strict';
+
+var _chai = require('chai');
+
+var _chai2 = _interopRequireDefault(_chai);
+
+var _chaiHttp = require('chai-http');
+
+var _chaiHttp2 = _interopRequireDefault(_chaiHttp);
+
+var _index = require('../index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var expect = _chai2.default.expect;
+
+var should = _chai2.default.should();
+_chai2.default.use(_chaiHttp2.default);
+
+// for put status
+var orderStatus = {
+  status: 'processing'
+};
+// admin token
+var token = process.env.TOKEN1;
+var dantoken = process.env.TOKEN2;
+// for post food
+var postFood = {
+  food: 'rice',
+  price: '340',
+  quantity: '1'
+};
+
+// .set('Authorization', `Bearer ${token}`)
+
+describe('API endpoint POST /orders', function () {
+  it('Should post orders given the user is logged in and token is sent through the headers', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/orders').set('Authorization', 'Bearer ' + dantoken).send(postFood).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body.data).to.be.an('Object');
+      res.body.data.should.have.property('food');
+      res.body.data.should.have.property('status').eql('new');
+    });
+  });
+
+  it('Should send an error if an Invalid token is sent. Token must be send with the header', function () {
+    return _chai2.default.request(_index2.default).post('/api/v1/orders').set('Authorization', 'Bearer jdjdj').send(postFood).then(function (res) {
+      expect(res).to.have.status(401);
+      res.body.should.have.property('message').eql('Authentication fail, Incorrect Token');
+    });
+  });
+});
+
+describe('API endpoint GET /orders', function () {
+  it('Should return all orders given an admin is logged in with valid credentials and token is sent through the headers', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/orders').set('Authorization', 'Bearer ' + token).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body.data).to.be.an('Array');
+      expect(res.body.data[0]).to.have.property('id');
+      res.body.data[0].should.have.property('id').eql(1);
+    });
+  });
+
+  it('Should return one order given an admin with valid credentials', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/orders/1').set('Authorization', 'Bearer ' + token).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body).to.be.an('object');
+      res.body.data.should.have.property('id').eql(1);
+    });
+  });
+
+  it('Should return not found when food ID is not in the database', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/orders/100').set('Authorization', 'Bearer ' + token).then(function (res) {
+      expect(res).to.have.status(404);
+      expect(res.body).to.be.an('object');
+      res.body.should.have.property('message').eql('Food not found');
+    });
+  });
+
+  it('ID must be a number and less than 9000', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/orders/1009999').set('Authorization', 'Bearer ' + token).then(function (res) {
+      expect(res).to.have.status(403);
+      expect(res.body).to.be.an('object');
+      res.body.should.have.property('message').eql('ID must be a number and less than 9000');
+    });
+  });
+
+  it('ID must not be a Letter', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/orders/hjj').set('Authorization', 'Bearer ' + token).then(function (res) {
+      expect(res).to.have.status(403);
+      expect(res.body).to.be.an('object');
+      res.body.should.have.property('message').eql('ID must be a number and less than 9000');
+    });
+  });
+
+  it('Invalid Route should give 404', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/anyroute').then(function (res) {
+      expect(res).to.have.status(404);
+      expect(res.body).to.have.property('error');
+      res.body.should.have.property('error').eql('Not Found');
+    });
+  });
+});
+// put orders
+describe('API endpoint PUT /orders/id', function () {
+  it('Should update order status when status is not empty and a valid status is given', function () {
+    return _chai2.default.request(_index2.default).put('/api/v1/orders/1').set('Authorization', 'Bearer ' + token).send(orderStatus).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body).to.be.an('object');
+      res.body.should.have.property('message').eql('Food Status Updated');
+    });
+  });
+});
+
+describe('API endpoint to GET total price of food ordered', function () {
+  it('Should return price of food all food ordered when an admin with valid credentials make request', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/total').set('Authorization', 'Bearer ' + token).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body).to.be.an('object');
+      res.body.should.have.property('message').eql('Success, Total Returned');
+    });
+  });
+});
+
+describe('API endpoint to GET a particular order', function () {
+  it('Should return order specific to a particular user with valid credentials', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/users/2/orders').set('Authorization', 'Bearer ' + dantoken).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body).to.be.an('object');
+    });
+  });
+
+  it('Should return error when a user with valid credentials try to access another person resource', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/users/3/orders').set('Authorization', 'Bearer ' + dantoken).then(function (res) {
+      expect(res).to.have.status(403);
+      expect(res.body).to.be.an('object');
+      res.body.should.have.property('message').eql('Auth Fail, You are not authorize to view this resource');
+    });
+  });
+
+  it('Should return error when a user pass in wrong token', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/users/2/orders').set('Authorization', 'Bearer jjlllk').then(function (res) {
+      expect(res).to.have.status(401);
+      expect(res.body).to.be.an('object');
+      res.body.should.have.property('message').eql('Authentication fail, Incorrect Token');
+    });
+  });
+
+  it('Should return error when no token is passed for a protected field', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/users/2/orders').then(function (res) {
+      expect(res).to.have.status(403);
+      expect(res.body).to.be.an('object');
+      res.body.should.have.property('message').eql('Authentication fail, Please provide Token');
+    });
+  });
+});

--- a/dist/test/user.js
+++ b/dist/test/user.js
@@ -1,0 +1,122 @@
+'use strict';
+
+var _chai = require('chai');
+
+var _chai2 = _interopRequireDefault(_chai);
+
+var _chaiHttp = require('chai-http');
+
+var _chaiHttp2 = _interopRequireDefault(_chaiHttp);
+
+var _index = require('../index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var expect = _chai2.default.expect;
+
+var should = _chai2.default.should();
+_chai2.default.use(_chaiHttp2.default);
+
+var token = process.env.TOKEN1;
+var usertoken = process.env.TOKEN2;
+
+describe('API endpoint for GET all users /users', function () {
+  it('Should return all users given an admin token is added', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/users').set('Authorization', 'Bearer ' + token).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body.data).to.be.an('Array');
+      res.body.should.have.property('type').eql('GET');
+      res.body.should.have.property('message').eql('All users returned successfully');
+    });
+  });
+
+  it('Should Return error if token is not added', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/users').then(function (res) {
+      expect(res).to.have.status(403);
+      res.body.should.have.property('message').eql('Authentication fail, Please provide Token');
+    });
+  });
+
+  it('Should Return error if Incorrect token is added', function () {
+    return _chai2.default.request(_index2.default).get('/api/v1/users').set('Authorization', 'Bearer dkdkdkdk').then(function (res) {
+      expect(res).to.have.status(401);
+      res.body.should.have.property('message').eql('Authentication fail, Incorrect Token');
+    });
+  });
+});
+
+describe('API endpoint to Update user roles using /users', function () {
+  it('Should update a user to admin', function () {
+    return _chai2.default.request(_index2.default).put('/api/v1/users/1').set('Authorization', 'Bearer ' + token).send({
+      roles: 'Admin'
+    }).then(function (res) {
+      expect(res).to.have.status(200);
+      expect(res.body).to.be.an('Object');
+      res.body.should.have.property('type').eql('PUT');
+      res.body.should.have.property('message').eql('User promoted to admin successfully');
+    });
+  });
+
+  it('Should return error if roles field is only whitespace', function () {
+    return _chai2.default.request(_index2.default).put('/api/v1/users/2').set('Authorization', 'Bearer ' + token).send({
+      roles: ' '
+    }).then(function (res) {
+      expect(res).to.have.status(400);
+      res.body.should.have.property('message').eql('roles must be included in the body');
+    });
+  });
+
+  it('Should return error if ID is not a number', function () {
+    return _chai2.default.request(_index2.default).put('/api/v1/users/dkddk').set('Authorization', 'Bearer ' + token).send({
+      roles: ' '
+    }).then(function (res) {
+      expect(res).to.have.status(403);
+      res.body.should.have.property('message').eql('ID must be a number and less than 9000');
+    });
+  });
+
+  it('Should return error if roles is not admin or user', function () {
+    return _chai2.default.request(_index2.default).put('/api/v1/users/1').set('Authorization', 'Bearer ' + token).send({
+      roles: 'dgddgh'
+    }).then(function (res) {
+      expect(res).to.have.status(400);
+      res.body.should.have.property('message').eql('Roles must be either Admin or Users');
+    });
+  });
+});
+
+describe('API endpoint for DELETE user /users', function () {
+  it('Should return success if an account is sucessfully deleted', function () {
+    return _chai2.default.request(_index2.default).delete('/api/v1/users').set('Authorization', 'Bearer ' + usertoken).then(function (res) {
+      expect(res).to.have.status(200);
+      res.body.should.have.property('type').eql('DELETE');
+      res.body.should.have.property('message').eql('Account successfully deleted');
+    });
+  });
+
+  it('Should Return error if token is not added', function () {
+    return _chai2.default.request(_index2.default).delete('/api/v1/users').then(function (res) {
+      expect(res).to.have.status(403);
+      res.body.should.have.property('message').eql('Authentication fail, Please provide Token');
+    });
+  });
+
+  it('Should Return error if Incorrect token is added', function () {
+    return _chai2.default.request(_index2.default).delete('/api/v1/users').set('Authorization', 'Bearer dkdkdkdk').then(function (res) {
+      expect(res).to.have.status(401);
+      res.body.should.have.property('message').eql('Authentication fail, Incorrect Token');
+    });
+  });
+});
+
+describe('API endpoint for DELETE users by ID /users/:id', function () {
+  it('Should return success if admin delete a user', function () {
+    return _chai2.default.request(_index2.default).delete('/api/v1/users/1').set('Authorization', 'Bearer ' + token).then(function (res) {
+      expect(res).to.have.status(200);
+      res.body.should.have.property('type').eql('DELETE');
+      res.body.should.have.property('message').eql('User Deleted successfully');
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?
This PR restrict admin from visiting order-list page and profile page. These pages are only for users

## Description of Task to be completed
- Get if the token provided is an admin
- Redirect them when they go to the pages

## How should this be manually tested
```
- Go to the website
- Register using valid admin credentials
- click on /order-list.html
-  it should redirect to admin-page.html
```
#### What are the relevant pivotal stories 
## Narrative:
An admin, Whenever I click on profile page, it should lead me to admin-page
 
## Acceptance Criteria:

Scenario: 
Given an admin
  And Login with Valid credentials
When I click to profile link
Then  I should be redirected to admin-page
## Branch name  
ft-profile-page-clicked-if-user-#161300484
